### PR TITLE
fix: import no-data img error fixed in order list master component

### DIFF
--- a/components/Orders/OrderList.tsx
+++ b/components/Orders/OrderList.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Image from 'next/image';
 import dynamic from 'next/dynamic';
 import useOrderListHook from '../../hooks/OrderListHooks/useOrderListHook';
-import image from '../../public/assets/images/no-data.svg';
+import image from '../../public/assets/images/no-data.png';
 const ListingTable = dynamic(() => import('./ListingTable'));
 import ComponentErrorHandler from '../ComponentErrorHandler';
 import OrderReportLoadingSkeleton from '../OrderReport/OrderReportLoadingSkeleton';


### PR DESCRIPTION
`import image from '../../public/assets/images/no-data.svg'; ` _x bad_

`import image from '../../public/assets/images/no-data.png'; ` _x correct_