### PR TITLE
fix: size added in size table when number of rows is zero

### DIFF
--- a/components/ProductDetailComponents/ProductDetailDrawer/ProductDetailInfo.tsx
+++ b/components/ProductDetailComponents/ProductDetailDrawer/ProductDetailInfo.tsx
@@ -109,7 +109,7 @@ const ProductDetailInfo = ({ data, getProductDetailData }: any) => {
     }
   };
   const handleSizeButtonClick = (size: number) => {
-    if (sizeTable[sizeTable.length - 1]?.size) {
+    if (sizeTable[sizeTable.length - 1]?.size || sizeTable?.length === 0) {
       const newRow = { ...initialState, size: size.toString() };
       setSizeTable([...sizeTable, newRow]);
     } else {


### PR DESCRIPTION
### Bug Fix: Attribute Table Size Addition  

**Problem**  
- After adding sizes to the attribute table, deleting all sizes, and attempting to add new sizes, no action was performed, and no sizes were added to the table.  

**Solution**  
1. Logic updated to handle the case where no records are present in the size table.  
2. Ensured that when sizes are clicked after the table is empty, a new record is added as expected.  

Let me know if further refinements are required!  
